### PR TITLE
Install setuptools in addition to pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 # tasks file for kifi.ec2backup
 
-- name: Install pip
+- name: Install setuptools and pip
   apt:
-    pkg=python-pip
-    state=present
-    update_cache=yes
-    cache_valid_time={{APT_CACHE_VALID_TIME}}
+    pkg:
+      - python-setuptools
+      - python-pip
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{ APT_CACHE_VALID_TIME }}"
 
 - name: Install boto
   pip:
@@ -30,7 +32,7 @@
   template: >
     src=ec2backup.yml.j2 dest={{ ec2backup_playbook_dir }}/ec2backup.yml
     owner=ec2backup group=ec2backup mode=0400
-    
+
 - name: Install a script for running the playbook
   template: >
     src=ec2backup.sh.j2 dest={{ ec2backup_playbook_dir }}/ec2backup.sh


### PR DESCRIPTION
The 'python-pip' only recommends 'python-setuptools' but does not depend
on it.  However, the next pip installation task ("Install boto")
requires setuptools to be installed.

The syntax was changed to the block style in order to install multiple
packages at the same time without a loop.